### PR TITLE
basic support for sexprs

### DIFF
--- a/rserve.js
+++ b/rserve.js
@@ -603,9 +603,27 @@ Robj = {
             }
         }
     }),
-    symbol: make_basic("symbol"),
+    symbol: make_basic("symbol", { 
+        json: function() {
+            return this.value;
+        }
+    }),
     list: make_basic("list"),
-    lang: make_basic("lang"),
+    lang: make_basic("lang", {
+        json: function() {
+            var values = _.map(this.value, function (x) { return x.json(); });
+            if (_.isUndefined(this.attributes)) {
+                return values;
+            } else {
+                var keys   = this.attributes.value.names.value;
+                var result = {};
+                _.each(keys, function(key, i) {
+                    result[key] = values[i];
+                });
+                return result;
+            }
+        }
+    }),
     tagged_list: make_basic("tagged_list"),
     tagged_lang: make_basic("tagged_lang"),
     vector_exp: make_basic("vector_exp"),


### PR DESCRIPTION
This patch treats lang elements just vectors, and sends the string in a symbol element along, to enable inspection of sexprs.
