### PR TITLE
bounds checking for one case in dataview

### DIFF
--- a/src/endian_aware_dataview.js
+++ b/src/endian_aware_dataview.js
@@ -102,12 +102,14 @@
                     this.buffer, this.offset + offset, this.buffer.byteLength);
             },
             view: function(new_offset, new_length) {
-                // FIXME Needs bounds checking
+                var ofs = this.offset + new_offset;
+                if(ofs + new_length > this.buffer.byteLength)
+                    throw new Error("Rserve.my_ArrayBufferView.view: bounds error: sgize: " +
+                                    this.buffer.byteLength + " offset: " + ofs + " length: " + new_length);
                 return Rserve.my_ArrayBufferView(
-                    this.buffer, this.offset + new_offset, new_length);
+                    this.buffer, ofs, new_length);
             }
         };
     };
 
 })(this);
-

--- a/src/endian_aware_dataview.js
+++ b/src/endian_aware_dataview.js
@@ -104,7 +104,7 @@
             view: function(new_offset, new_length) {
                 var ofs = this.offset + new_offset;
                 if(ofs + new_length > this.buffer.byteLength)
-                    throw new Error("Rserve.my_ArrayBufferView.view: bounds error: sgize: " +
+                    throw new Error("Rserve.my_ArrayBufferView.view: bounds error: size: " +
                                     this.buffer.byteLength + " offset: " + ofs + " length: " + new_length);
                 return Rserve.my_ArrayBufferView(
                     this.buffer, ofs, new_length);


### PR DESCRIPTION
probably there are other places where this is needed, but this one
had a FIXME comment, and it helps diagnose problems we are seeing with
messages apparently being broken into frames/fragments