### PR TITLE
piece together chunked messages

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -208,13 +208,74 @@ function read(m)
     return that;
 }
 
+var incomplete_ = [], incomplete_header_ = null, msg_bytes_ = 0, remaining_ = 0;
+function clear_incomplete() {
+    incomplete_ = [];
+    incomplete_header_ = null;
+    remaining_ = 0;
+    msg_bytes_ = 0;
+}
+
 function parse(msg)
 {
     var result = {};
+    if(incomplete_.length) {
+        result.header = incomplete_header_;
+        incomplete_.push(msg);
+        remaining_ -= msg.byteLength;
+        if(remaining_ < 0) {
+            result.ok = false;
+            result.message = "Messages add up to more than expected length: got " +
+                            (msg_bytes_-remaining_) + ", expected " + msg_bytes_;
+            clear_incomplete();
+            return result;
+        }
+        else if(remaining_ === 0) {
+            var complete_msg = new ArrayBuffer(msg_bytes_),
+                array = new Uint8Array(complete_msg),
+                offset = 0;
+            incomplete_.forEach(function(frame, i) {
+                array.set(new Uint8Array(frame), offset);
+                offset += frame.byteLength;
+            });
+            if(offset !== msg_bytes_) {
+                result.ok = false;
+                result.message = "Internal error - frames added up to " + offset + " not " + msg_bytes_;
+                clear_incomplete();
+                return result;
+            }
+            clear_incomplete();
+            msg = complete_msg;
+        }
+        else {
+            result.ok = true;
+            result.incomplete = true;
+            return result;
+        }
+    }
+
     var header = new Int32Array(msg, 0, 4);
     var resp = header[0] & 16777215, status_code = header[0] >> 24;
+    var length = header[1], length_high = header[3];
     var msg_id = header[2];
     result.header = [resp, status_code, msg_id];
+
+    if(length_high) {
+        result.ok = false;
+        result.message = "rserve.js cannot handle messages larger than 4GB";
+        return result;
+    }
+
+    if(length > msg.byteLength) {
+        incomplete_.push(msg);
+        incomplete_header_ = header;
+        msg_bytes_ = length + 16; // header length + data length
+        remaining_ = msg_bytes_ - msg.byteLength;
+        result.header = header;
+        result.ok = true;
+        result.incomplete = true;
+        return result;
+    }
 
     if (resp === Rserve.Rsrv.RESP_ERR) {
         result.ok = false;

--- a/src/rserve.js
+++ b/src/rserve.js
@@ -159,6 +159,8 @@ Rserve.create = function(opts) {
             return;
         }
         var v = Rserve.parse_websocket_frame(msg.data);
+        if(v.incomplete)
+            return;
         var msg_id = v.header[2], cmd = v.header[0] & 0xffffff;
         var queue = _.find(queues, function(queue) { return queue.msg_id == msg_id; });
         // console.log("onmessage, queue=" + (queue ? queue.name : "<unknown>") + ", ok= " + v.ok+ ", cmd=" + cmd +", msg_id="+ msg_id);


### PR DESCRIPTION
websockets don't guarantee that the entire original message will be sent
in one go.  this patch uses the length in the QAP header to determine if
the entire message has been received.

as long as the message is not complete, it holds the frames in an array.
once the sum of the sizes of the frames equals the length in the QAP
header plus the header size, it reassembles the messages and passes it on.